### PR TITLE
Fixed a bug with observers

### DIFF
--- a/source/SRCameraView.h
+++ b/source/SRCameraView.h
@@ -37,6 +37,7 @@
 @property (nonatomic, readonly) SRCamera *rearCamera;
 @property (nonatomic, readonly) SRCamera *currentCamera;
 @property (nonatomic, readonly) AVCaptureDevicePosition currentCameraPosition;
+@property (nonatomic, assign) AVCaptureFlashMode flashMode;
 
 // setting either point-of-interest's indicator image will automatically change this to YES
 @property (nonatomic, readwrite, assign) BOOL shouldDrawPointsOfInterest;

--- a/source/SRCameraView.m
+++ b/source/SRCameraView.m
@@ -64,9 +64,8 @@ static void *kSRCameraViewObserverContext = &kSRCameraViewObserverContext;
 
 #pragma mark - Class Methods
 
-+ (BOOL)deviceHasCamera
-{
-	if([UIImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera]) {
++ (BOOL)deviceHasCamera {
+	if ([UIImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera]) {
 		return YES;
 	} else {
 		return NO;
@@ -75,44 +74,34 @@ static void *kSRCameraViewObserverContext = &kSRCameraViewObserverContext;
 
 #pragma mark - Init & Dealloc
 
-- (id)init
-{
-	self = [super init];
-	if(self) {
-		BOOL setupWasOK = [self sharedSetup];
-		if(setupWasOK == NO) {
+- (id)init {
+	if (self = [super init]) {
+		if (![self sharedSetup]) {
 			return nil;
 		}
 	}
 	return self;
 }
 
-- (id)initWithFrame:(CGRect)frame
-{
-    self = [super initWithFrame:frame];
-    if(self) {
-		BOOL setupWasOK = [self sharedSetup];
-		if(setupWasOK == NO) {
+- (id)initWithFrame:(CGRect)frame {
+    if (self = [super initWithFrame:frame]) {
+		if (![self sharedSetup]) {
 			return nil;
 		}
     }
     return self;
 }
 
-- (id)initWithCoder:(NSCoder *)aDecoder
-{
-	self = [super initWithCoder:aDecoder];
-	if(self) {
-		BOOL setupWasOK = [self sharedSetup];
-		if(setupWasOK == NO) {
+- (id)initWithCoder:(NSCoder *)aDecoder {
+	if (self = [super initWithCoder:aDecoder]) {
+		if (![self sharedSetup]) {
 			return nil;
 		}
 	}
 	return self;
 }
 
-- (void)dealloc
-{
+- (void)dealloc {
 	[_captureSession stopRunning];
 	
 	[self removeObserver:self forKeyPath:@"focusPointOfInterestIndicator" context:kSRCameraViewObserverContext];
@@ -124,33 +113,32 @@ static void *kSRCameraViewObserverContext = &kSRCameraViewObserverContext;
 #if __has_feature(objc_arc) && __IPHONE_OS_VERSION_MIN_REQUIRED >= 60000
 	// Do nothing
 #else
-	if(_videoPreviewQueue) {
+	if (_videoPreviewQueue) {
 		dispatch_release(_videoPreviewQueue);
 	}
 #endif
 }
 
-- (BOOL)sharedSetup
-{
+- (BOOL)sharedSetup {
 	_captureSession = [[AVCaptureSession alloc] init];
 	_captureSession.sessionPreset = AVCaptureSessionPresetPhoto;
 	
 	_rearCamera = [SRCamera cameraWithPosition:AVCaptureDevicePositionBack];
 	_frontCamera = [SRCamera cameraWithPosition:AVCaptureDevicePositionFront];
 	
-	if(_rearCamera != nil) {
+	if (_rearCamera != nil) {
 		_currentCamera = _rearCamera;
 		_currentCameraPosition = AVCaptureDevicePositionBack;
-	} else if(_frontCamera != nil) {
+	} else if (_frontCamera != nil) {
 		_currentCamera = _frontCamera;
 		_currentCameraPosition = AVCaptureDevicePositionFront;
 	}
 	
-	if(_rearCamera == nil && _frontCamera ==  nil) {
+	if (_rearCamera == nil && _frontCamera ==  nil) {
 		return NO;
 	}
 	
-	if(_currentCamera.hasFlash == YES) {
+	if (_currentCamera.hasFlash == YES) {
 		_currentCamera.flashMode = AVCaptureFlashModeOff;
 	}
 	
@@ -177,7 +165,7 @@ static void *kSRCameraViewObserverContext = &kSRCameraViewObserverContext;
 	self.clipsToBounds = YES;
 	self.layer.masksToBounds = YES;
 	
-	if([_previewLayer respondsToSelector:@selector(captureDevicePointOfInterestForPoint:)]) {
+	if ([_previewLayer respondsToSelector:@selector(captureDevicePointOfInterestForPoint:)]) {
 		_hasCaptureDevicePointOfInterestForPoint = YES;
 	} else {
 		_hasCaptureDevicePointOfInterestForPoint = NO;
@@ -213,33 +201,29 @@ static void *kSRCameraViewObserverContext = &kSRCameraViewObserverContext;
 
 #pragma mark - Layout Management
 
-- (void)layoutSubviews
-{
+- (void)layoutSubviews {
 	_previewLayer.frame = self.layer.bounds;
 }
 
 #pragma mark - Start & Stop
 
-- (void)start
-{
+- (void)start {
 	[self.captureSession startRunning];
 	self.paused = NO;
 }
 
-- (void)stop
-{
+- (void)stop {
 	[self.captureSession stopRunning];
 }
 
 #pragma mark - Camera Handling
 
-- (void)scanStillImageConnections
-{
+- (void)scanStillImageConnections {
 	AVCaptureConnection *videoConnection = nil;
 	
 	for(AVCaptureConnection *connection in self.stillImageOutput.connections) {
 		for(AVCaptureInputPort *port in connection.inputPorts) {
-			if([port.mediaType isEqual:AVMediaTypeVideo]) {
+			if ([port.mediaType isEqual:AVMediaTypeVideo]) {
 				videoConnection = connection;
 				break;
 			}
@@ -249,8 +233,7 @@ static void *kSRCameraViewObserverContext = &kSRCameraViewObserverContext;
 	self.captureConnection = videoConnection;
 }
 
-- (void)useCamera:(SRCamera *)camera
-{
+- (void)useCamera:(SRCamera *)camera {
 	[self.captureSession beginConfiguration];
 	
 	NSArray *inputs = self.captureSession.inputs;
@@ -265,35 +248,31 @@ static void *kSRCameraViewObserverContext = &kSRCameraViewObserverContext;
 	_currentCamera = camera;
 }
 
-- (void)useFrontCamera
-{
-	if(self.frontCamera != nil) {
+- (void)useFrontCamera {
+	if (self.frontCamera != nil) {
 		[self useCamera:self.frontCamera];
 		_currentCameraPosition = AVCaptureDevicePositionFront;
 		[self scanStillImageConnections];
 	}
 }
 
-- (void)useRearCamera
-{
-	if(self.rearCamera != nil) {
+- (void)useRearCamera {
+	if (self.rearCamera != nil) {
 		[self useCamera:self.rearCamera];
 		_currentCameraPosition = AVCaptureDevicePositionBack;
 		[self scanStillImageConnections];
 	}
 }
 
-- (void)swapCameras
-{
-	if(_currentCameraPosition == AVCaptureDevicePositionBack) {
+- (void)swapCameras {
+	if (_currentCameraPosition == AVCaptureDevicePositionBack) {
 		[self useFrontCamera];
 	} else {
 		[self useRearCamera];
 	}
 }
 
-- (void)takePhotoWithCompletionBlock:(void (^)(UIImage *, UIImage *))takePhotoCompletionBlock
-{
+- (void)takePhotoWithCompletionBlock:(void (^)(UIImage *, UIImage *))takePhotoCompletionBlock {
 	UIImage *(^completionBlock)(UIImage *photo, UIImage *preview) = [takePhotoCompletionBlock copy];
 	
 	self.paused = YES;
@@ -320,8 +299,7 @@ static void *kSRCameraViewObserverContext = &kSRCameraViewObserverContext;
 
 // For converting from view coordinates to camera coordinates on iOS 5
 // From Apple's AVCam example
-- (CGPoint)convertToPointOfInterestFromViewCoordinates:(CGPoint)viewCoordinates
-{
+- (CGPoint)convertToPointOfInterestFromViewCoordinates:(CGPoint)viewCoordinates {
 #if __IPHONE_OS_VERSION_MIN_REQUIRED < 60000
     CGPoint pointOfInterest = CGPointMake(.5f, .5f);
     CGSize frameSize = self.frame.size;
@@ -397,11 +375,10 @@ static void *kSRCameraViewObserverContext = &kSRCameraViewObserverContext;
 
 #pragma mark - Key-Value Observing
 
-- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
-{
-	if(context == kSRCameraViewObserverContext) {
-		if([keyPath isEqualToString:@"paused"]) {
-			if(_paused == NO) {
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context {
+	if (context == kSRCameraViewObserverContext) {
+		if ([keyPath isEqualToString:@"paused"]) {
+			if (_paused == NO) {
 				_shouldCapturePreviewImage = NO;
 				dispatch_async(dispatch_get_main_queue(), ^{
 					self.previewPausedView.hidden = YES;
@@ -409,10 +386,10 @@ static void *kSRCameraViewObserverContext = &kSRCameraViewObserverContext;
 			} else {
 				_shouldCapturePreviewImage = YES;
 			}
-		} else if([keyPath isEqualToString:@"focusPointOfInterestIndicator"]) {
-			if(self.focusPointOfInterestIndicator != nil) {
+		} else if ([keyPath isEqualToString:@"focusPointOfInterestIndicator"]) {
+			if (self.focusPointOfInterestIndicator != nil) {
 				dispatch_async(dispatch_get_main_queue(), ^{
-					if(self.focusPointIndicatorView != nil) {
+					if (self.focusPointIndicatorView != nil) {
 						[self.focusPointIndicatorView removeFromSuperview];
 						self.focusPointIndicatorView = nil;
 					}
@@ -424,10 +401,10 @@ static void *kSRCameraViewObserverContext = &kSRCameraViewObserverContext;
 					self.focusPointIndicatorView = fpv;
 				});
 			}
-		} else if([keyPath isEqualToString:@"exposurePointOfInterestIndicator"]) {
-			if(self.exposurePointOfInterestIndicator != nil) {
+		} else if ([keyPath isEqualToString:@"exposurePointOfInterestIndicator"]) {
+			if (self.exposurePointOfInterestIndicator != nil) {
 				dispatch_async(dispatch_get_main_queue(), ^{
-					if(self.exposurePointIndicatorView != nil) {
+					if (self.exposurePointIndicatorView != nil) {
 						[self.exposurePointIndicatorView removeFromSuperview];
 						self.exposurePointIndicatorView = nil;
 					}
@@ -439,13 +416,13 @@ static void *kSRCameraViewObserverContext = &kSRCameraViewObserverContext;
 					self.exposurePointIndicatorView = epv;
 				});
 			}
-		} else if([keyPath isEqualToString:@"previewLayerGravity"]) {
+		} else if ([keyPath isEqualToString:@"previewLayerGravity"]) {
 			self.previewLayer.videoGravity = self.previewLayerGravity;
-			if([self.previewLayerGravity isEqualToString:AVLayerVideoGravityResize]) {
+			if ([self.previewLayerGravity isEqualToString:AVLayerVideoGravityResize]) {
 				self.previewPausedView.contentMode = UIViewContentModeScaleToFill;
-			} else if([self.previewLayerGravity isEqualToString:AVLayerVideoGravityResizeAspect]) {
+			} else if ([self.previewLayerGravity isEqualToString:AVLayerVideoGravityResizeAspect]) {
 				self.previewPausedView.contentMode = UIViewContentModeScaleAspectFit;
-			} else if([self.previewLayerGravity isEqualToString:AVLayerVideoGravityResizeAspectFill]) {
+			} else if ([self.previewLayerGravity isEqualToString:AVLayerVideoGravityResizeAspectFill]) {
 				self.previewPausedView.contentMode = UIViewContentModeScaleAspectFill;
 			} else {
 				[NSException raise:NSInvalidArgumentException format:@"invalid preview layer gravity: %@", self.previewLayerGravity];
@@ -461,9 +438,8 @@ static void *kSRCameraViewObserverContext = &kSRCameraViewObserverContext;
 #pragma mark - AVCaptureVideoDataOutputSampleBufferDelegate Methods
 
 - (void)captureOutput:(AVCaptureOutput *)captureOutput didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer
-	   fromConnection:(AVCaptureConnection *)connection
-{
-	if(_shouldCapturePreviewImage == YES) {
+	   fromConnection:(AVCaptureConnection *)connection {
+	if (_shouldCapturePreviewImage == YES) {
 		_shouldCapturePreviewImage = NO;
 		
 		UIImage *previewImage = [UIImage imageWithCMSampleBuffer:sampleBuffer];
@@ -477,39 +453,36 @@ static void *kSRCameraViewObserverContext = &kSRCameraViewObserverContext;
 
 #pragma mark - Setters & Getters
 
-- (BOOL)setCurrentCameraFocusPoint:(CGPoint)focusPoint
-{
+- (BOOL)setCurrentCameraFocusPoint:(CGPoint)focusPoint {
 	return [self setCurrentCameraFocusPoint:focusPoint withFocusMode:AVCaptureFocusModeAutoFocus];
 }
 
-- (BOOL)setCurrentCameraExposurePoint:(CGPoint)exposurePoint
-{
+- (BOOL)setCurrentCameraExposurePoint:(CGPoint)exposurePoint {
 	return [self setCurrentCameraExposurePoint:exposurePoint withExposureMode:AVCaptureExposureModeContinuousAutoExposure];
 }
 
-- (BOOL)setCurrentCameraFocusPoint:(CGPoint)focusPoint withFocusMode:(AVCaptureFocusMode)focusMode
-{
+- (BOOL)setCurrentCameraFocusPoint:(CGPoint)focusPoint withFocusMode:(AVCaptureFocusMode)focusMode {
 	BOOL success = NO;
 	
-	if(self.currentCamera.focusPointOfInterestSupported) {
+	if (self.currentCamera.focusPointOfInterestSupported) {
 		CGPoint cameraPoint;
-		if(_hasCaptureDevicePointOfInterestForPoint) {
+		if (_hasCaptureDevicePointOfInterestForPoint) {
 			cameraPoint = [_previewLayer captureDevicePointOfInterestForPoint:focusPoint];
 		} else {
 			cameraPoint = [self convertToPointOfInterestFromViewCoordinates:focusPoint];
 		}
 		
-		if([self.currentCamera setFocusPointOfInterest:cameraPoint withFocusMode:focusMode] == YES) {
+		if ([self.currentCamera setFocusPointOfInterest:cameraPoint withFocusMode:focusMode] == YES) {
 			success = YES;
 			
-			if(self.shouldDrawPointsOfInterest) {
+			if (self.shouldDrawPointsOfInterest) {
 				self.focusPointIndicatorView.center = focusPoint;
 				self.focusPointIndicatorView.alpha = 1.0;
 				self.focusPointIndicatorView.hidden = NO;
 				[UIView animateWithDuration:0.3 animations:^{
 					self.focusPointIndicatorView.alpha = 0.0;
 				} completion:^(BOOL finished) {
-					if(finished == YES) {
+					if (finished == YES) {
 						self.focusPointIndicatorView.hidden = YES;
 					}
 				}];
@@ -520,29 +493,28 @@ static void *kSRCameraViewObserverContext = &kSRCameraViewObserverContext;
 	return success;
 }
 
-- (BOOL)setCurrentCameraExposurePoint:(CGPoint)exposurePoint withExposureMode:(AVCaptureExposureMode)exposureMode
-{
+- (BOOL)setCurrentCameraExposurePoint:(CGPoint)exposurePoint withExposureMode:(AVCaptureExposureMode)exposureMode {
 	BOOL success = NO;
 	
-	if(self.currentCamera.exposurePointOfInterestSupported) {
+	if (self.currentCamera.exposurePointOfInterestSupported) {
 		CGPoint cameraPoint;
-		if(_hasCaptureDevicePointOfInterestForPoint) {
+		if (_hasCaptureDevicePointOfInterestForPoint) {
 			cameraPoint = [_previewLayer captureDevicePointOfInterestForPoint:exposurePoint];
 		} else {
 			cameraPoint = [self convertToPointOfInterestFromViewCoordinates:exposurePoint];
 		}
 		
-		if([self.currentCamera setExposurePointOfInterest:cameraPoint withExposureMode:exposureMode]) {
+		if ([self.currentCamera setExposurePointOfInterest:cameraPoint withExposureMode:exposureMode]) {
 			success = YES;
 			
-			if(self.shouldDrawPointsOfInterest) {
+			if (self.shouldDrawPointsOfInterest) {
 				self.exposurePointIndicatorView.center = exposurePoint;
 				self.exposurePointIndicatorView.alpha = 1.0;
 				self.exposurePointIndicatorView.hidden = NO;
 				[UIView animateWithDuration:0.3 animations:^{
 					self.exposurePointIndicatorView.alpha = 0.0;
 				} completion:^(BOOL finished) {
-					if(finished == YES) {
+					if (finished == YES) {
 						self.exposurePointIndicatorView.hidden = YES;
 					}
 				}];

--- a/source/SRCameraView.m
+++ b/source/SRCameraView.m
@@ -2,6 +2,7 @@
 //  SRCameraView.m
 /*
  Copyright (c) 2012, 2013 Sean Ridenour
+ Copyright (c) 2014, Sean Ridenour, Tancrède Chazallet
  
  Permission is hereby granted, free of charge, to any person obtaining a copy of
  this software and associated documentation files (the "Software"), to deal in

--- a/source/SRCameraView.m
+++ b/source/SRCameraView.m
@@ -500,5 +500,26 @@ static void *kSRCameraViewObserverContext = &kSRCameraViewObserverContext;
 	return success;
 }
 
+- (void)setFlashMode:(AVCaptureFlashMode)flashMode {
+	AVCaptureDevice *cameraDevice = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeVideo];
+	
+	NSError* err = nil;
+	
+	if (![cameraDevice lockForConfiguration:&err]) {
+		NSLog(@"SRCameraView couldn't get exclusive access to camera when setting flash");
+	} else {
+		// flip on the flash mode
+		if ([cameraDevice hasFlash] && [cameraDevice isFlashModeSupported:flashMode]) {
+			[cameraDevice setFlashMode:flashMode];
+		}
+		
+		[cameraDevice unlockForConfiguration];
+	}
+}
+
+- (AVCaptureFlashMode)flashMode {
+	return [[AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeVideo] flashMode];
+}
+
 @end
 


### PR DESCRIPTION
Since init is called in initWithFrame and initWithCoder, it was source of code repetition and so of bug to call a setup for each of them.
Was causing a bug on dealloc since kV observers were added twice.
